### PR TITLE
github/libp2p: Remove infra team and move stongo to member

### DIFF
--- a/github/libp2p/membership.json
+++ b/github/libp2p/membership.json
@@ -303,7 +303,7 @@
     "role": "member"
   },
   "stongo": {
-    "role": "admin"
+    "role": "member"
   },
   "stuckinaboot": {
     "role": "member"

--- a/github/libp2p/team.json
+++ b/github/libp2p/team.json
@@ -79,11 +79,6 @@
     "parent_team_id": 2100801,
     "privacy": "closed"
   },
-  "infra": {
-    "id": "3152313",
-    "parent_team_id": null,
-    "privacy": "closed"
-  },
   "w3dt-stewards": {
     "id": "4657013",
     "parent_team_id": null,

--- a/github/libp2p/team_membership.json
+++ b/github/libp2p/team_membership.json
@@ -493,11 +493,6 @@
       "role": "member"
     }
   },
-  "infra": {
-    "stongo": {
-      "role": "maintainer"
-    }
-  },
   "w3dt-stewards": {
     "BigLep": {
       "role": "maintainer"

--- a/github/libp2p/team_repository.json
+++ b/github/libp2p/team_repository.json
@@ -1279,11 +1279,6 @@
       "permission": "push"
     }
   },
-  "infra": {
-    "dht-tracer": {
-      "permission": "pull"
-    }
-  },
   "w3dt-stewards": {
     "community": {
       "permission": "admin"


### PR DESCRIPTION
Periodic permission audit.

- Removes the unused infra team.
- Moves user stongo from admin to member.

@stongo let me know in case you ever need these permissions again.

@galargh mind giving this a review. Hope I did everything correctly.
