### PR TITLE
Populate the Bifrost team

### DIFF
--- a/github/libp2p/membership.json
+++ b/github/libp2p/membership.json
@@ -140,6 +140,9 @@
   "geoah": {
     "role": "member"
   },
+  "gmasgras": {
+    "role": "member"
+  },
   "guseggert": {
     "role": "member"
   },
@@ -222,6 +225,9 @@
     "role": "member"
   },
   "mbaxter": {
+    "role": "member"
+  },
+  "mcamou": {
     "role": "member"
   },
   "mcollina": {
@@ -309,6 +315,9 @@
     "role": "member"
   },
   "stuckinaboot": {
+    "role": "member"
+  },
+  "thattommyhall": {
     "role": "member"
   },
   "thomaseizinger": {

--- a/github/libp2p/team_membership.json
+++ b/github/libp2p/team_membership.json
@@ -198,6 +198,17 @@
       "role": "member"
     }
   },
+  "Bifrost": {
+    "gmasgras": {
+      "role": "member"
+    },
+    "mcamou": {
+      "role": "member"
+    },
+    "thattommyhall": {
+      "role": "member"
+    }
+  },
   "Repos - Go": {
     "BigLep": {
       "role": "member"


### PR DESCRIPTION
This PR adds @gmasgras, @mcamou and @thattommyhall to https://github.com/orgs/libp2p/teams/bifrost

Adding them didn't work before - https://github.com/libp2p/github-mgmt/pull/15 - because they were not members of the `libp2p` organization.
