### PR TITLE
fix: cleanup go-libp2p-relay-daemon permissions

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -1192,16 +1192,15 @@ repositories:
     visibility: public
   go-libp2p-relay-daemon:
     collaborators:
-      admin:
-        - marten-seemann
       push:
-        - vyzo
         - web3-bot
     description: A standalone libp2p circuit relay daemon providing relay service
       for versions v1 and v2 of the protocol.
     teams:
-      push:
+      admin:
         - w3dt-stewards
+      push:
+        - Repos - Go
     visibility: public
   go-libp2p-rendezvous:
     description: Go implementation of rendezvous protocol


### PR DESCRIPTION
IIUC by default most repos are supposed to look like:
- web3-bot gets push
- w3dt-stewards gets admin (maybe Admin gets admin too, or maybe that group is no longer required)
- Repos-Go (for Go repos) gets push

Probably with some other defaults we can't set in here like:
- master/main is protected and requires an approval to merge
- nobody gets to tag since that's done by CI

Looked at this repo since I was tagged by @hsanjuan and noticed #32 (which might be fine, but this change should probably happen either way)