### PR TITLE
Add web3-bot to libp2p/js-libp2p-webtransport as a push collaborator

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -3276,7 +3276,8 @@ repositories:
     archived: false
     collaborators:
       admin:
-        - MarcoPolo
+        - Admin
+        - w3dt-stewards
       push:
         - web3-bot
     default_branch: main

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -3277,6 +3277,8 @@ repositories:
     collaborators:
       admin:
         - MarcoPolo
+      push:
+        - web3-bot
     default_branch: main
     description: "WebTranport module that libp2p uses and that implements the
       interface-transport spec "


### PR DESCRIPTION
Required by https://github.com/protocol/.github/pull/402