### PR TITLE
chore: introduce rust-libp2p Maintainers team

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4050,17 +4050,6 @@ teams:
         - mpetrunic
         - wemeetagain
     privacy: closed
-  rust-libp2p Maintainers:
-    description: Trusted reviewers for merging into rust-libp2p repositories.
-    members:
-      maintainer:
-        - BigLep
-        - mxinden
-      member:
-        - elenaf9
-        - jxs
-        - thomaseizinger
-    parent_team_id: Repos - Rust
   Repos - Go:
     description: For all things go-libp2p
     members:
@@ -4126,6 +4115,17 @@ teams:
         - vmx
         - yusefnapora
     privacy: closed
+  rust-libp2p Maintainers:
+    description: Trusted reviewers for merging into rust-libp2p repositories.
+    members:
+      maintainer:
+        - BigLep
+        - mxinden
+      member:
+        - elenaf9
+        - jxs
+        - thomaseizinger
+    parent_team_id: Repos - Rust
   Specs contributors:
     members:
       member:

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -3677,6 +3677,8 @@ repositories:
       admin:
         - Admin
         - w3dt-stewards
+      maintain:
+        - rust-libp2p Maintainers
       push:
         - Repos - Rust
     topics:
@@ -3725,6 +3727,8 @@ repositories:
     teams:
       admin:
         - w3dt-stewards
+      maintain:
+        - rust-libp2p Maintainers
       push:
         - Repos - Rust
     visibility: public
@@ -4046,6 +4050,17 @@ teams:
         - mpetrunic
         - wemeetagain
     privacy: closed
+  rust-libp2p Maintainers:
+    description: Trusted reviewers for merging into rust-libp2p repositories.
+    members:
+      maintainer:
+        - BigLep
+        - mxinden
+      member:
+        - elenaf9
+        - jxs
+        - thomaseizinger
+    parent_team_id: Repos - Rust
   Repos - Go:
     description: For all things go-libp2p
     members:
@@ -4106,6 +4121,7 @@ teams:
       member:
         - AgeManning
         - elenaf9
+        - jxs
         - thomaseizinger
         - vmx
         - yusefnapora


### PR DESCRIPTION
### Summary
Introduce a `rust-libp2p Maintainers` team and add the team as `maintain` for `rust-libp2p` and `rust-yamux`

### Why do you need this?
Requested by @thomaseizinger and the rust-libp2p team in order to manage their repositories.

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
