### PR TITLE
Remove biglep@ from rust-libp2p Maintainers

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4123,7 +4123,6 @@ teams:
     description: Trusted reviewers for merging into rust-libp2p repositories.
     members:
       maintainer:
-        - BigLep
         - mxinden
       member:
         - elenaf9


### PR DESCRIPTION
### Summary
Removing @biglep from rust-libp2p Maintainers

### Why do you need this?
I'm removing myself:
1. So I don't get all the notifications
2. Because I don't meet the requirements "Trusted reviewers for merging into rust-libp2p repositories."

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
