### PR TITLE
chore: add ChainSafe maintainers to webtransport and prometheus. add ckousik as collaborator to js-libp2p

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -3181,6 +3181,11 @@ repositories:
     files:
       .github/workflows/stale.yml:
         content: .github/workflows/stale.yml
+    teams:
+      admin:
+        - Admin
+        - js-libp2p ChainSafe Maintainers
+        - w3dt-stewards
     visibility: public
   js-libp2p-pubsub-peer-discovery:
     archived: false
@@ -3559,6 +3564,7 @@ repositories:
     teams:
       admin:
         - Admin
+        - js-libp2p ChainSafe Maintainers
         - w3dt-stewards
     visibility: public
   js-libp2p:
@@ -3575,6 +3581,9 @@ repositories:
         - w3dt-stewards
       push:
         - Repos - JavaScript
+    collaborators:
+      push:
+        - ckousik
     topics:
       - ipfs
       - js-ipfs

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -3182,7 +3182,7 @@ repositories:
       .github/workflows/stale.yml:
         content: .github/workflows/stale.yml
     teams:
-      admin:
+      push:
         - Admin
         - js-libp2p ChainSafe Maintainers
         - w3dt-stewards

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -3564,8 +3564,9 @@ repositories:
     teams:
       admin:
         - Admin
-        - js-libp2p ChainSafe Maintainers
         - w3dt-stewards
+      push:
+        - js-libp2p ChainSafe Maintainers
     visibility: public
   js-libp2p:
     archived: false

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -3569,6 +3569,9 @@ repositories:
     visibility: public
   js-libp2p:
     archived: false
+    collaborators:
+      push:
+        - ckousik
     default_branch: master
     description: The JavaScript Implementation of libp2p networking stack.
     files:
@@ -3581,9 +3584,6 @@ repositories:
         - w3dt-stewards
       push:
         - Repos - JavaScript
-    collaborators:
-      push:
-        - ckousik
     topics:
       - ipfs
       - js-ipfs


### PR DESCRIPTION
### Summary
add ChainSafe maintainers to webtransport and prometheus. add ckousik as collaborator to js-libp2p

### Why do you need this?
Need to give these folks the right permissions

### What else do we need to know?
N/A

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
