### PR TITLE
chore: archive older webrtc repos

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -3441,7 +3441,7 @@ repositories:
         - Repos - JavaScript
     visibility: public
   js-libp2p-webrtc-direct:
-    archived: false
+    archived: true
     collaborators:
       admin:
         - vasco-santos
@@ -3461,7 +3461,7 @@ repositories:
         - Repos - JavaScript
     visibility: public
   js-libp2p-webrtc-peer:
-    archived: false
+    archived: true
     collaborators:
       admin:
         - achingbrain
@@ -3474,7 +3474,7 @@ repositories:
         content: .github/workflows/stale.yml
     visibility: public
   js-libp2p-webrtc-star:
-    archived: false
+    archived: true
     collaborators:
       admin:
         - vasco-santos


### PR DESCRIPTION
### Summary
Archives https://github.com/libp2p/js-libp2p-webrtc-direct, https://github.com/libp2p/js-libp2p-webrtc-star, and https://github.com/libp2p/js-libp2p-webrtc-peer
Complementary to https://github.com/libp2p/github-mgmt/pull/74
Addresses https://github.com/libp2p/js-libp2p/issues/385

### Why do you need this?
We no longer maintain these repos as they are being deprecated in favor of solutions based on https://github.com/libp2p/specs/tree/master/webrtc (https://github.com/little-bear-labs/js-libp2p-webrtc/pull/4) and https://github.com/libp2p/specs/issues/475

### What else do we need to know?
Todo:
 - [ ] update README.md in each repo before merging this PR

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
