### PR TITLE
chore: make w3dt-stewards admin of js-libp2p-webrtc-peer

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -3465,6 +3465,7 @@ repositories:
     collaborators:
       admin:
         - achingbrain
+        - w3dt-stewards
       push:
         - web3-bot
     default_branch: master


### PR DESCRIPTION
### Summary
make w3dt-stewards admin of js-libp2p-webrtc-peer

### Why do you need this?
Am not able to push changes to the repo needed for https://github.com/libp2p/github-mgmt/pull/80

### What else do we need to know?
N/A

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
