### PR TITLE
fix: w3dt-stewards should be under team not collaborators

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -3465,7 +3465,6 @@ repositories:
     collaborators:
       admin:
         - achingbrain
-        - w3dt-stewards
       push:
         - web3-bot
     default_branch: master
@@ -3473,6 +3472,12 @@ repositories:
     files:
       .github/workflows/stale.yml:
         content: .github/workflows/stale.yml
+    teams:
+      admin:
+        - Admin
+        - w3dt-stewards
+      push:
+        - Repos - JavaScript
     visibility: public
   js-libp2p-webrtc-star:
     archived: false


### PR DESCRIPTION
### Summary
w3dt-stewards should be under team not collaborators

### Why do you need this?
fixes a bug on master introduced by https://github.com/libp2p/github-mgmt/pull/82

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
