### PR TITLE
add Dennis to the org

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -35,6 +35,7 @@ members:
     - cemozerr
     - ChihChengLiang
     - DannyS03
+    - dennis-tra
     - dharmapunk82
     - dignifiedquire
     - dirkmc


### PR DESCRIPTION
### Summary
Adds Dennis to the libp2p org.

### Why do you need this?
Dennis needs permission to create repos in the libp2p org so that he can transfer https://github.com/dennis-tra/punchr/ here.

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
