### PR TITLE
docs(rust-libp2p): Document crates.io access

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4859,7 +4859,8 @@ teams:
         - yusefnapora
     privacy: closed
   rust-libp2p Maintainers:
-    description: Trusted reviewers for merging into rust-libp2p repositories and publishing to crates.io.
+    description: Trusted reviewers for merging into rust-libp2p repositories and
+      publishing to crates.io.
     members:
       maintainer:
         - mxinden

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4859,7 +4859,7 @@ teams:
         - yusefnapora
     privacy: closed
   rust-libp2p Maintainers:
-    description: Trusted reviewers for merging into rust-libp2p repositories.
+    description: Trusted reviewers for merging into rust-libp2p repositories and publishing to crates.io.
     members:
       maintainer:
         - mxinden


### PR DESCRIPTION
### Summary

Document that members of the "rust-libp2p Maintainers" team have publish access to the many rust-libp2p crates.io crates.

See
https://github.com/libp2p/rust-libp2p/discussions/3174#discussioncomment-4354958 for details.

### Why do you need this?

To make sure future changes are done with caution.

### What else do we need to know?

**DRI:** myself

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
