### PR TITLE
fix: Remove julian from repos-go and go-libp2p-maintainers

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4774,7 +4774,6 @@ teams:
         - marten-seemann
       member:
         - iand
-        - julian88110
         - MarcoPolo
         - vyzo
     parent_team_id: Repos - Go
@@ -4811,7 +4810,6 @@ teams:
         - hannahhoward
         - hsanjuan
         - iand
-        - julian88110
         - Kubuxu
         - lidel
         - MarcoPolo


### PR DESCRIPTION
### Summary

Missed in https://github.com/libp2p/github-mgmt/pull/77.
<!-- include a short summary of the request -->

### Why do you need this?

If I am not mistaken, Alumni don't need any group membership. Please correct me if I am wrong @galargh.

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
