### PR TITLE
Update required rust-libp2p workflows

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4309,9 +4309,6 @@ repositories:
             - Compile with select features (mdns tcp dns async-std)
             - Compile with select features (mdns tcp dns tokio)
             - IPFS Integration tests
-            - run-ping-interop-cross-implementation / Run a test with different
-              versions
-            - run-ping-interop-cross-version / Run a test with different versions
             - rustfmt
             - Test libp2p-autonat
             - Test libp2p-core


### PR DESCRIPTION
### Summary
Update required rust-libp2p workflows to remove the stale interoperability tests. Addresses https://github.com/libp2p/test-plans/pull/99#issuecomment-1383439416

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
