### PR TITLE
fix name of the required interop-tests on rust-libp2p

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4309,7 +4309,7 @@ repositories:
             - Compile with select features (mdns tcp dns async-std)
             - Compile with select features (mdns tcp dns tokio)
             - IPFS Integration tests
-            - Run testplans test
+            - Run multidimensional interoperability tests / Run testplans test
             - rustfmt
             - Test libp2p-autonat
             - Test libp2p-core


### PR DESCRIPTION
### Summary
Sorry, turns out it's not what we thought it was on https://github.com/libp2p/github-mgmt/pull/107#discussion_r1082086427
see:

![image](https://user-images.githubusercontent.com/1204690/213733180-3b8395d0-0681-4882-ad73-e04b738fa82b.png)
on https://github.com/libp2p/rust-libp2p/pull/3360
I now took the name from [here](https://github.com/libp2p/rust-libp2p/actions/runs/3968612014/jobs/6802174937) but I am not sure if will fix. Anyone with more experience feel free to chime in. 



### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
