### PR TITLE
libp2p: rename rust-libp2p interop workflow

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4334,7 +4334,7 @@ repositories:
             - Compile with select features (mdns tcp dns async-std)
             - Compile with select features (mdns tcp dns tokio)
             - IPFS Integration tests
-            - Run multidimensional interoperability tests / Run testplans test
+            - Interoperability Testing / Run multidimensional interoperability tests
             - rustfmt
             - Test libp2p-autonat
             - Test libp2p-core

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4333,8 +4333,9 @@ repositories:
             - Compile on x86_64-pc-windows-msvc
             - Compile with select features (mdns tcp dns async-std)
             - Compile with select features (mdns tcp dns tokio)
+            - Interoperability Testing / Run multidimensional interoperability
+              tests
             - IPFS Integration tests
-            - Interoperability Testing / Run multidimensional interoperability tests
             - rustfmt
             - Test libp2p-autonat
             - Test libp2p-core


### PR DESCRIPTION
### Summary
Renames the `rust-libp2p` interop workflow to accomodate for https://github.com/libp2p/rust-libp2p/pull/3414/

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
