### PR TITLE
Add guillaumemichel to members

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -51,6 +51,7 @@ members:
     - geoah
     - gmasgras
     - Gozala
+    - guillaumemichel
     - guseggert
     - haadcode
     - hacdias


### PR DESCRIPTION
### Summary
Add [guillaumemichel](https://github.com/guillaumemichel) to members

### Why do you need this?
I am contributing to [go-libp2p-kad-dht](https://github.com/libp2p/go-libp2p-kad-dht) and [go-libp2p-kbucket](https://github.com/libp2p/go-libp2p/kbucket), and want to be able to assign folks for reviews on my issues and PRs.

**DRI:** [Guillaume Michel](https://github.com/guillaumemichel)

### Reviewer's Checklist
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
