### PR TITLE
added guillaumemichel to w3dt-stewards

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4930,6 +4930,7 @@ teams:
         - Stebalien
       member:
         - achingbrain
+        - guillaumemichel
         - guseggert
         - Jorropo
         - laurentsenta


### PR DESCRIPTION
### Summary

added guillaumemichel to w3dt-stewards

### Why do you need this?

Contribute more on [go-libp2p-kad-dht](https://github.com/libp2p/go-libp2p-kad-dht), and I want to be able to assign reviewers to my PRs.

**DRI:** [guillaumemichel](https://github.com/guillaumemichel)

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
