### PR TITLE
Revert "chore: Enable semantic pr check in go and rust"

### DIFF
--- a/scripts/src/actions/fix-yaml-config.ts
+++ b/scripts/src/actions/fix-yaml-config.ts
@@ -10,10 +10,8 @@ addFileToAllRepos(
   (repository: Repository) => repository.name !== 'fclibp2p-zhi'
 )
 addFileToAllRepos(
-  '.github/workflows/action-semantic-pull-request.yml',
-  '.github/workflows/action-semantic-pull-request.yml',
-  (repository: Repository) => (repository.name.startsWith('js-libp2p')
-                                || repository.name == 'go-libp2p'
-                                || repository.name == 'rust-libp2p')
+  '.github/workflows/semantic-pull-request.yml',
+  '.github/workflows/semantic-pull-request.yml',
+  (repository: Repository) => repository.name.startsWith('js-libp2p')
 )
 format()


### PR DESCRIPTION
@galargh this reverts libp2p/github-mgmt#121
I'd like to have sign off from the go-libp2p and rust-libp2p maintainers before merging