### PR TITLE
Revert "feat(rust-libp2p): update job name due to crate rename"

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4461,7 +4461,7 @@ repositories:
             - Test libp2p-yamux
             - Test libp2p
             - Test multistream-select
-            - Test quick-protobuf-codec
+            - Test prost-codec
             - Test rw-stream-sink
           strict: true
     default_branch: master


### PR DESCRIPTION
Reverts libp2p/github-mgmt#126

Was merged a bit too quickly.