### PR TITLE
chore: add sukunrt as a member of go-libp2p

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -117,6 +117,7 @@ members:
     - snazha-blkio
     - stongo
     - stuckinaboot
+    - sukunrt
     - thattommyhall
     - thomaseizinger
     - tinytb
@@ -4941,6 +4942,7 @@ teams:
         - MarcoPolo
         - masih
         - petar
+        - sukunrt
         - vyzo
         - willscott
         - yusefnapora


### PR DESCRIPTION
### Summary
@sukunrt is a OSS contributor to go-libp2p, adding the associated GitHub account here in order to reflect that

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
