### PR TITLE
feat(rust-libp2p): remove hard-requirement of an approving review

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4417,7 +4417,7 @@ repositories:
         required_pull_request_reviews:
           dismiss_stale_reviews: false
           require_code_owner_reviews: false
-          required_approving_review_count: 1
+          required_approving_review_count: 0
           restrict_dismissals: false
         required_status_checks:
           contexts:


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->

I am proposing to remove the hard-requirement for an approval to merge PRs in `rust-libp2p`. The different timezones and work schedules of @mxinden and myself sometimes make it unnecessarily difficult for me to make progress.

I say removing the **hard**-requirement because I'd still consider there to be a soft-requirement of getting a code review from other maintainers for non-trivial changes. It is PRs like https://github.com/libp2p/rust-libp2p/pull/3486 that end up causing unnecessary churn with no real benefit of the "code review" that is required to merge them.

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
