### PR TITLE
Update jvm-libp2p admins and members

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -115,6 +115,7 @@ members:
     - romanb
     - SgtPooki
     - snazha-blkio
+    - StefanBratanov
     - stongo
     - stuckinaboot
     - thattommyhall
@@ -4107,6 +4108,7 @@ repositories:
     teams:
       admin:
         - Admin
+        - Nashatyrev
         - w3dt-stewards
       push:
         - Repos - Java

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -115,7 +115,6 @@ members:
     - romanb
     - SgtPooki
     - snazha-blkio
-    - StefanBratanov
     - stongo
     - stuckinaboot
     - thattommyhall
@@ -4102,6 +4101,8 @@ repositories:
     collaborators:
       admin:
         - Nashatyrev
+      push:
+        - StefanBratanov
     default_branch: develop
     delete_branch_on_merge: false
     description: a libp2p implementation for the JVM, written in Kotlin 🔥 [WIP]

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4099,6 +4099,9 @@ repositories:
           restrict_dismissals: false
         required_status_checks:
           strict: false
+    collaborators:
+      admin:
+        - Nashatyrev
     default_branch: develop
     delete_branch_on_merge: false
     description: a libp2p implementation for the JVM, written in Kotlin 🔥 [WIP]
@@ -4108,7 +4111,6 @@ repositories:
     teams:
       admin:
         - Admin
-        - Nashatyrev
         - w3dt-stewards
       push:
         - Repos - Java


### PR DESCRIPTION
### Summary
- Add @Nashatyrev (myself) as an admin of `jvm-libp2p` repo
- Add @StefanBratanov as a member of libp2p organization

### Why do you need this?

I'm managing `jvm-libp2p` repo starting from its creation and periodically need to add new contributors for this repo
@StefanBratanov is contributing to the `jvm-libp2p` as a part of his Ethereum https://github.com/ConsenSys/teku contributions

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
