### PR TITLE
add advocates to libp2p

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -14,6 +14,7 @@ members:
     - Stebalien
     - whyrusleeping
   member:
+    - 2color
     - aamnv
     - aarshkshah1992
     - achingbrain
@@ -119,6 +120,7 @@ members:
     - stuckinaboot
     - sukunrt
     - thattommyhall
+    - TheDiscordian
     - thomaseizinger
     - tinytb
     - tomaka
@@ -5025,4 +5027,12 @@ teams:
         - MarcoPolo
         - mxinden
         - p-shahi
+    privacy: closed
+  community:
+    description: Developer advocates, community engineers, and other people that need
+      write privs.
+    members:
+      maintainer:
+        - 2color
+        - TheDiscordian
     privacy: closed

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4860,6 +4860,14 @@ teams:
       member:
         - ipfsbot
     privacy: closed
+  community:
+    description: Developer advocates, community engineers, and other people that
+      need write privs.
+    members:
+      maintainer:
+        - 2color
+        - TheDiscordian
+    privacy: closed
   contributors:
     members:
       member:
@@ -5027,12 +5035,4 @@ teams:
         - MarcoPolo
         - mxinden
         - p-shahi
-    privacy: closed
-  community:
-    description: Developer advocates, community engineers, and other people that need
-      write privs.
-    members:
-      maintainer:
-        - 2color
-        - TheDiscordian
     privacy: closed


### PR DESCRIPTION
### Summary

Add IPFS advocates to the libp2p org

### Why do you need this?

https://github.com/libp2p/universal-connectivity/issues/1

### What else do we need to know?


**DRI:** @p-shahi 


### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
