### PR TITLE
Kubo maintainers team

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4961,6 +4961,19 @@ teams:
         - mpetrunic
         - wemeetagain
     privacy: closed
+  kubo maintainers:
+    create_default_maintainer: false
+    description: Kubo Maintainers
+    members:
+      maintainer:
+        - aschmahmann
+        - BigLep
+        - lidel
+      member:
+        - guseggert
+        - hacdias
+        - Jorropo
+    privacy: closed
   Repos - Go:
     description: For all things go-libp2p
     members:


### PR DESCRIPTION
### Summary
Added a Kubo maintainers team, which is a copy of the [team in the ipfs org](https://github.com/ipfs/github-mgmt/blob/d8bfce1a65dfcc34ba5f780b9aaaf5c68916d2cc/github/ipfs.yml#L6020). 

### Why do you need this?
The Kubo maintainers team is required in the libp2p org for shared ownership of the [go-libp2p-kad-dht](https://github.com/libp2p/go-libp2p-kad-dht) repo (see https://github.com/libp2p/go-libp2p-kad-dht/pull/828).

**DRI:** @guillaumemichel 

### Reviewer's Checklist
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
