### PR TITLE
fix: update go-libp2p maintainers

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -7181,9 +7181,9 @@ teams:
       maintainer:
         - BigLep
         - marten-seemann
-      member:
-        - iand
         - MarcoPolo
+      member:
+        - sukunrt
         - vyzo
     parent_team_id: Repos - Go
     privacy: closed

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -7180,8 +7180,8 @@ teams:
     members:
       maintainer:
         - BigLep
-        - marten-seemann
         - MarcoPolo
+        - marten-seemann
       member:
         - sukunrt
         - vyzo


### PR DESCRIPTION
### Summary
### Why do you need this?
Need to update the maintainers list

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
