### PR TITLE
use reusable workflows for workflows distributed via github-mgmt

### DIFF
--- a/files/.github/workflows/semantic-pull-request.yml
+++ b/files/.github/workflows/semantic-pull-request.yml
@@ -1,4 +1,4 @@
-name: "Semantic PR"
+name: Semantic PR
 
 on:
   pull_request_target:
@@ -9,32 +9,4 @@ on:
 
 jobs:
   main:
-    name: Validate PR title
-    runs-on: ubuntu-latest
-    steps:
-      - uses: amannn/action-semantic-pull-request@b6bca70dcd3e56e896605356ce09b76f7e1e0d39 # v5.1.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # Configure which types are allowed (newline delimited).
-          types: |
-            feat
-            fix
-            chore
-            docs
-            deps
-            test
-            refactor
-            ci
-          requireScope: false
-
-      - name: Check PR title length
-        env:
-          TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          title_length=${#TITLE}
-          if [ $title_length -gt 72 ]
-          then
-            echo "PR title is too long (greater than 72 characters)"
-            exit 1
-          fi
+    uses: pl-strflt/.github/workflows/semantic-pull-request.yml@v0.1

--- a/files/.github/workflows/semantic-pull-request.yml
+++ b/files/.github/workflows/semantic-pull-request.yml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   main:
-    uses: pl-strflt/.github/workflows/semantic-pull-request.yml@v0.1
+    uses: pl-strflt/.github/.github/workflows/reusable-semantic-pull-request.yml@v0.3

--- a/files/.github/workflows/stale.yml
+++ b/files/.github/workflows/stale.yml
@@ -6,21 +6,4 @@ on:
 
 jobs:
   stale:
-
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
-
-    steps:
-    - uses: actions/stale@v3
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Oops, seems like we needed more information for this issue, please comment with more details or this issue will be closed in 7 days.'
-        close-issue-message: 'This issue was closed because it is missing author input.'
-        stale-issue-label: 'kind/stale'
-        any-of-labels: 'need/author-input'
-        exempt-issue-labels: 'need/triage,need/community-input,need/maintainer-input,need/maintainers-input,need/analysis,status/blocked,status/in-progress,status/ready,status/deferred,status/inactive'
-        days-before-issue-stale: 6
-        days-before-issue-close: 7
-        enable-statistics: true
+    uses: pl-strflt/.github/workflows/stale-issue.yml@v0.1

--- a/files/.github/workflows/stale.yml
+++ b/files/.github/workflows/stale.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   stale:
-    uses: pl-strflt/.github/workflows/stale-issue.yml@v0.1
+    uses: pl-strflt/.github/.github/workflows/reusable-stale-issue.yml@v0.3


### PR DESCRIPTION
This will help us keep the workflows up to date without the constant need to deploy workflows everywhere. The reusable workflows will live here - https://github.com/pl-strflt/.github - because they're likely to be reused in other orgs too.

I'll test it in one or two repos before pulling the trigger on mass-deployment.