### PR TITLE
Move guseggert to alumni

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -3819,8 +3819,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: true
-    collaborators:
-      admin:
     default_branch: main
     delete_branch_on_merge: false
     description: Infrastructure for Hydra Boosters

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -3821,7 +3821,6 @@ repositories:
     archived: true
     collaborators:
       admin:
-        - guseggert
     default_branch: main
     delete_branch_on_merge: false
     description: Infrastructure for Hydra Boosters
@@ -7624,6 +7623,7 @@ teams:
         - fsdiogo
         - gavinmcdermott
         - geoah
+        - guseggert
         - haadcode
         - hacdias
         - iceseer
@@ -7767,7 +7767,6 @@ teams:
         - BigLep
         - lidel
       member:
-        - guseggert
         - hacdias
         - Jorropo
     privacy: closed
@@ -7861,7 +7860,6 @@ teams:
         - achingbrain
         - dhuseby
         - guillaumemichel
-        - guseggert
         - Jorropo
         - laurentsenta
         - lidel


### PR DESCRIPTION
### Summary

Removing @guseggert from all but alumni team.

@guseggert do you still need permissions beyond what `alumni` provides?

I guess it goes without saying, but I am more than happy to re-introduce these permissions in case you ever need them again. 

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
