### PR TITLE
add probelab team to go-libp2p-kad-dht maintainers

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -7755,6 +7755,15 @@ teams:
         - galargh
         - laurentsenta
     privacy: closed
+  probelab:
+    create_default_maintainer: false
+    members:
+      maintainer:
+        - yiannisbot
+        - guillaumemichel
+        - iand
+        - dennis-tra
+    privacy: closed
   js-libp2p ChainSafe Maintainers:
     members:
       member:

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -1947,6 +1947,7 @@ repositories:
       maintain:
         - go-libp2p Maintainers
         - kubo maintainers
+        - probelab
       push:
         - Repos - Go
     topics:

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -7755,15 +7755,6 @@ teams:
         - galargh
         - laurentsenta
     privacy: closed
-  probelab:
-    create_default_maintainer: false
-    members:
-      maintainer:
-        - yiannisbot
-        - guillaumemichel
-        - iand
-        - dennis-tra
-    privacy: closed
   js-libp2p ChainSafe Maintainers:
     members:
       member:
@@ -7781,6 +7772,15 @@ teams:
       member:
         - hacdias
         - Jorropo
+    privacy: closed
+  probelab:
+    create_default_maintainer: false
+    members:
+      maintainer:
+        - dennis-tra
+        - guillaumemichel
+        - iand
+        - yiannisbot
     privacy: closed
   Repos - Go:
     description: For all things go-libp2p


### PR DESCRIPTION
### Summary

ProbeLab took up the work of revamping the DHT implementation to pave the path for things like the composable DHT, reprovide sweep, and double hashing.

### Why do you need this?

We're splitting responsibility between boxo, go-libp2p-kad-dht, and go-kademlia. Therefore we want to be able develop against go-libp2p-kad-dht.

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

-

**DRI:** myself

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request




cc @iand 
