### PR TITLE
Add stewards to js-libp2p-prometheus-metrics admin team

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -5401,11 +5401,12 @@ repositories:
     squash_merge_commit_message: PR_BODY
     squash_merge_commit_title: PR_TITLE
     teams:
-      push:
+      admin:
         - Admin
+        - w3dt-stewards
+      push:
         - js-libp2p ChainSafe Maintainers
         - Repos - JavaScript
-        - w3dt-stewards
     visibility: public
   js-libp2p-pubsub-peer-discovery:
     advanced_security: false


### PR DESCRIPTION
### Summary

Add stewards to js-libp2p-prometheus-metrics admin team

### Why do you need this?

For stewards to administer the js-libp2p-prometheus-metrics repo

### What else do we need to know?

Nothing

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
