### PR TITLE
Add js-libp2p-dev team and CODEOWNERS files

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4112,6 +4112,9 @@ repositories:
     files:
       .github/workflows/stale.yml:
         content: .github/workflows/stale.yml
+      CODEOWNERS:
+        content: |
+          * @libp2p/js-libp2p-dev
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -4284,6 +4287,9 @@ repositories:
           jobs:
             stale:
               uses: pl-strflt/.github/.github/workflows/reusable-stale-issue.yml@v0.3
+      CODEOWNERS:
+        content: |
+          * @libp2p/js-libp2p-dev
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -4341,6 +4347,9 @@ repositories:
         content: .github/workflows/semantic-pull-request.yml
       .github/workflows/stale.yml:
         content: .github/workflows/stale.yml
+      CODEOWNERS:
+        content: |
+          * @libp2p/js-libp2p-dev
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -4631,6 +4640,9 @@ repositories:
         content: .github/workflows/semantic-pull-request.yml
       .github/workflows/stale.yml:
         content: .github/workflows/stale.yml
+      CODEOWNERS:
+        content: |
+          * @libp2p/js-libp2p-dev
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -4661,6 +4673,9 @@ repositories:
         content: .github/workflows/semantic-pull-request.yml
       .github/workflows/stale.yml:
         content: .github/workflows/stale.yml
+      CODEOWNERS:
+        content: |
+          * @libp2p/js-libp2p-dev
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -4690,6 +4705,9 @@ repositories:
         content: .github/workflows/semantic-pull-request.yml
       .github/workflows/stale.yml:
         content: .github/workflows/stale.yml
+      CODEOWNERS:
+        content: |
+          * @libp2p/js-libp2p-dev
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -5430,6 +5448,9 @@ repositories:
         content: .github/workflows/semantic-pull-request.yml
       .github/workflows/stale.yml:
         content: .github/workflows/stale.yml
+      CODEOWNERS:
+        content: |
+          * @libp2p/js-libp2p-dev
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -6311,6 +6332,9 @@ repositories:
         content: .github/workflows/semantic-pull-request.yml
       .github/workflows/stale.yml:
         content: .github/workflows/stale.yml
+      CODEOWNERS:
+        content: |
+          * @libp2p/js-libp2p-dev
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -7788,6 +7812,18 @@ teams:
       member:
         - mpetrunic
         - wemeetagain
+    privacy: closed
+  js-libp2p-dev:
+    create_default_maintainer: false
+    description: js-libp2p developers and engineers
+    members:
+      maintainer:
+        - achingbrain
+      member:
+        - maschad
+        - SgtPooki
+        - wemeetagain
+        - whizzzkid
     privacy: closed
   kubo maintainers:
     create_default_maintainer: false


### PR DESCRIPTION
### Summary

Creates a `js-libp2p-dev` team similar to the `helia-dev` team and adds `CODEOWNERS` files to live repos to automatically tag `js-libp2p-dev` members as reviewers in opened PRs.

### Why do you need this?

To auto-tag certain devs as PR reviewers.

### What else do we need to know?

N/a

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
