### PR TITLE
fix(universal-connectivity): move and correct codeowners file

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -7421,13 +7421,13 @@ repositories:
     default_branch: main
     delete_branch_on_merge: false
     files:
-      .github/workflows/stale.yml:
-        content: .github/workflows/stale.yml
       .github/CODEOWNERS:
         content: |
           /rust-peer/ @libp2p/rust-libp2p-maintainers
           /go-peer/   @libp2p/go-libp2p-maintainers
           /js-peer/   @libp2p/js-libp2p-dev
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -7425,9 +7425,9 @@ repositories:
         content: .github/workflows/stale.yml
       .github/CODEOWNERS:
         content: |
-          rust-peer/ @libp2p/rust-libp2p-maintainers
-          go-peer/   @libp2p/go-libp2p-maintainers
-          js-peer/   @libp2p/js-libp2p-dev
+          /rust-peer/ @libp2p/rust-libp2p-maintainers
+          /go-peer/   @libp2p/go-libp2p-maintainers
+          /js-peer/   @libp2p/js-libp2p-dev
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -7423,11 +7423,11 @@ repositories:
     files:
       .github/workflows/stale.yml:
         content: .github/workflows/stale.yml
-      CODEOWNERS:
+      .github/CODEOWNERS:
         content: |
-          rust-peer/* @libp2p/rust-libp2p-maintainers
-          go-peer/* @libp2p/go-libp2p-maintainers
-          js-peer/* @libp2p/js-libp2p-dev
+          rust-peer/ @libp2p/rust-libp2p-maintainers
+          go-peer/   @libp2p/go-libp2p-maintainers
+          js-peer/   @libp2p/js-libp2p-dev
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->

The syntax of this file is quite subtle. Using `*` only matches direct files within that directory instead of all nested files. See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file.

To not clutter the repository root too much, I am also moving this file to the `.github` directory.

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
