### PR TITLE
feat(rust-libp2p): remove obsolete job

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -7123,7 +7123,6 @@ repositories:
             - Test libp2p-tcp
             - Test libp2p-tls
             - Test libp2p-uds
-            - Test libp2p-wasm-ext
             - Test libp2p-webrtc
             - Test libp2p-websocket
             - Test libp2p-webtransport-websys


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->

This component is being removed from our repository so we need to delete its job: https://github.com/libp2p/rust-libp2p/pull/4694

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
