### PR TITLE
Grant dhuseby admin access to the org

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -14,6 +14,9 @@ members:
     # 3. general long-standing sysadmin for these organizations with his past roles at PL Inc
     # 4. This isn't andyschwab's day-to-day GitHub account
     - andyschwab-admin
+    # Why @dhuseby?
+    # It's temporary; to migrate from PL fleek account to libp2p fleek account
+    - dhuseby
     # Why @galargh?
     # 1. co-founder of [IPDX](https://ipdx.co), and IPDX is contracted to look after GitHub for this organization.
     # 2. Multiple years of experience managing GitHub organizations of open source projects, including this org.
@@ -45,7 +48,6 @@ members:
     - daviddias
     - dennis-tra
     - dharmapunk82
-    - dhuseby
     - dignifiedquire
     - dirkmc
     - dryajov


### PR DESCRIPTION
Fixed https://github.com/libp2p/github-mgmt/pull/203

The original PR didn't remove the entry from the `members.member` list - that's why the role in the organization wasn't changed (FYI, it's always a good idea to inspect the plan posted by the automation to see if it matches your expectations - https://github.com/libp2p/github-mgmt/pull/203#issuecomment-1949384496 - in that case, it was saying that it didn't plan on making any changes).

It'd be a good feature request to either automatically fix double-entries or at least explicitly warn PR creators about double-entries.
