### PR TITLE
tweaking rust-libp2p permissions

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4231,7 +4231,6 @@ repositories:
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
       admin:
-        - Admin
         - w3dt-stewards
         - rust-libp2p Active Maintainers
       maintain:
@@ -4362,7 +4361,6 @@ repositories:
     squash_merge_commit_title: PR_TITLE
     teams:
       admin:
-        - Admin
         - w3dt-stewards
         - rust-libp2p Active Maintainers
       maintain:
@@ -4443,7 +4441,6 @@ repositories:
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
       admin:
-        - Admin
         - w3dt-stewards
         - rust-libp2p Active Maintainers
       maintain:

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4232,8 +4232,8 @@ repositories:
     teams:
       admin:
         - Admin
-        - w3dt-stewards
         - rust-libp2p Active Maintainers
+        - w3dt-stewards
       maintain:
         - rust-libp2p Maintainers
       pull:
@@ -4363,8 +4363,8 @@ repositories:
     teams:
       admin:
         - Admin
-        - w3dt-stewards
         - rust-libp2p Active Maintainers
+        - w3dt-stewards
       maintain:
         - rust-libp2p Maintainers
       pull:
@@ -4444,8 +4444,8 @@ repositories:
     teams:
       admin:
         - Admin
-        - w3dt-stewards
         - rust-libp2p Active Maintainers
+        - w3dt-stewards
       maintain:
         - rust-libp2p Maintainers
       pull:
@@ -5030,11 +5030,11 @@ teams:
     description: "In Rust we tRust "
     members:
       member:
-        - mxinden
-        - tomaka
         - AgeManning
         - jxs
+        - mxinden
         - thomaseizinger
+        - tomaka
         - vmx
     privacy: closed
   rust-libp2p Active Maintainers:
@@ -5044,7 +5044,8 @@ teams:
         - jxs
     privacy: closed
   rust-libp2p Maintainers:
-    description: Trusted maintainers, past and present, for merging into rust-libp2p repositories and publishing to crates.io.
+    description: Trusted maintainers, past and present, for merging into rust-libp2p
+      repositories and publishing to crates.io.
     members:
       maintainer:
         - jxs

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4230,6 +4230,10 @@ repositories:
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
+      admin:
+        - Admin
+        - w3dt-stewards
+        - rust-libp2p Active Maintainers
       maintain:
         - rust-libp2p Maintainers
       pull:
@@ -4360,6 +4364,7 @@ repositories:
       admin:
         - Admin
         - w3dt-stewards
+        - rust-libp2p Active Maintainers
       maintain:
         - rust-libp2p Maintainers
       pull:
@@ -4438,7 +4443,9 @@ repositories:
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
       admin:
+        - Admin
         - w3dt-stewards
+        - rust-libp2p Active Maintainers
       maintain:
         - rust-libp2p Maintainers
       pull:
@@ -5022,24 +5029,28 @@ teams:
   Repos - Rust:
     description: "In Rust we tRust "
     members:
-      maintainer:
+      member:
         - mxinden
         - tomaka
-      member:
         - AgeManning
         - jxs
         - thomaseizinger
         - vmx
     privacy: closed
+  rust-libp2p Active Maintainers:
+    description: Active maintainers of rust-libp2p repositories with Admin privileges.
+    members:
+      member:
+        - jxs
+    privacy: closed
   rust-libp2p Maintainers:
-    description: Trusted reviewers for merging into rust-libp2p repositories and
-      publishing to crates.io.
+    description: Trusted maintainers, past and present, for merging into rust-libp2p repositories and publishing to crates.io.
     members:
       maintainer:
         - jxs
-        - mxinden
       member:
         - MarcoPolo
+        - mxinden
         - thomaseizinger
     privacy: closed
   Specs contributors:


### PR DESCRIPTION
### Summary
This permissions change does a few things:
* It moves all of the "Repos - rust" team members to just members so that maintenance of that team has to go through an Admin of the libp2p org.
* It separates the rust-libp2p Maintainers into two teams: "rust-libp2p Active Maintainers" with just the currently active maintainers and "rust-libp2p Maintainers" with past and present maintainers that we still trust as reviewers. The former is granted Admin permissions over just the rust-libp2p repos. This was necessary because the other teams with Admin permissions have scopes much larger than the rust-libp2p repos.
* Correctly sets the "rust-libp2p Active Maintainers" to include @jxs as a member but NOT a maintainer of that team. He will have Admin rights over the libp2p repos but will not be able to add any members to the "rust-libp2p Active Maintainers" list without going through an Admin of the libp2p org.
* Correctly demotes @mxinden from a "maintainer" of the "rust-libp2p Maintainers" team down to just a "member"

### Why do you need this?
There are some cases where a trusted and active maintainer of the rust-libp2p repos must merge a PR and bypass the required checks. This is rare, but does happen.

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
