### PR TITLE
demoting myself now that the Fleek migration is complete

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -14,9 +14,6 @@ members:
     # 3. general long-standing sysadmin for these organizations with his past roles at PL Inc
     # 4. This isn't andyschwab's day-to-day GitHub account
     - andyschwab-admin
-    # Why @dhuseby?
-    # It's temporary; to migrate from PL fleek account to libp2p fleek account
-    - dhuseby
     # Why @galargh?
     # 1. co-founder of [IPDX](https://ipdx.co), and IPDX is contracted to look after GitHub for this organization.
     # 2. Multiple years of experience managing GitHub organizations of open source projects, including this org.
@@ -48,6 +45,7 @@ members:
     - daviddias
     - dennis-tra
     - dharmapunk82
+    - dhuseby
     - dignifiedquire
     - dirkmc
     - dryajov


### PR DESCRIPTION
### Summary
Demotes myself from libp2p org Admin to just an org member.

### Why do you need this?
My Admin permissions were only temporary to facilitate the migration of the libp2p websites to Fleek.

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
