### PR TITLE
fixing the permissions on website-new

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4677,6 +4677,9 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
+    collaborators:
+      admin:
+        - momack2
     default_branch: main
     delete_branch_on_merge: false
     description: Rebuild of the libp2p.io website
@@ -4691,8 +4694,13 @@ repositories:
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
+      admin:
+        - Admin
+        - w3dt-stewards
       pull:
         - github-mgmt stewards
+      push:
+        - ci
     visibility: public
   website:
     advanced_security: false


### PR DESCRIPTION
### Summary
Fixes the permissions on the website-new repo so that I can merge more changes.

### Why do you need this?
There is an outstanding PR in the website-new repo that cannot be merged because the website-new repo doesn't have the correct permissions granted. This PR gives the website-new repo the same permissions as the website repo.

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
