### PR TITLE
fixes jxs permissions with rust-libp2p

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4239,6 +4239,8 @@ repositories:
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
+      admin:
+        - rust-libp2p Active Maintainers
       maintain:
         - rust-libp2p Maintainers
       pull:
@@ -4369,6 +4371,7 @@ repositories:
       admin:
         - Admin
         - w3dt-stewards
+        - rust-libp2p Active Maintainers
       maintain:
         - rust-libp2p Maintainers
       pull:
@@ -4448,6 +4451,7 @@ repositories:
     teams:
       admin:
         - w3dt-stewards
+        - rust-libp2p Active Maintainers
       maintain:
         - rust-libp2p Maintainers
       pull:
@@ -5059,9 +5063,12 @@ teams:
         - vmx
     privacy: closed
   rust-libp2p Active Maintainers:
+    description: Active maintainers who need occassional admin over rust-libp2p repos.
     members:
       maintainer:
         - galargh
+      member:
+        - jxs
     privacy: closed
   rust-libp2p Maintainers:
     description: Trusted reviewers for merging into rust-libp2p repositories and

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4370,8 +4370,8 @@ repositories:
     teams:
       admin:
         - Admin
-        - w3dt-stewards
         - rust-libp2p Active Maintainers
+        - w3dt-stewards
       maintain:
         - rust-libp2p Maintainers
       pull:
@@ -4450,8 +4450,8 @@ repositories:
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
       admin:
-        - w3dt-stewards
         - rust-libp2p Active Maintainers
+        - w3dt-stewards
       maintain:
         - rust-libp2p Maintainers
       pull:


### PR DESCRIPTION
### Summary
Promotes @jxs to be the active maintainer of rust-libp2p.

### Why do you need this?
As the active maintainer, @jxs occasionally needs to do admin things and this fixes that. He's not an org admin, just an admin on rust-libp2p related repos.

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
