### PR TITLE
add @AgeManning as rust-libp2p maintainer

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -5075,6 +5075,7 @@ teams:
       maintainer:
         - galargh
       member:
+        - AgeManning
         - jxs
     privacy: closed
   rust-libp2p Maintainers:
@@ -5085,6 +5086,7 @@ teams:
         - jxs
         - mxinden
       member:
+        - AgeManning
         - MarcoPolo
         - thomaseizinger
     privacy: closed


### PR DESCRIPTION
### Summary
Adding @AgeManning as rust-libp2p maintainer to help @jxs.

### Why do you need this?
Currently @jxs is the only maintainer of rust-libp2p. @AgeManning has generously volunteered to help out.

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
