### PR TITLE
Make Stebalien a temporary admin to configure issue deletion

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -22,6 +22,8 @@ members:
     # 1. co-founder of [IPDX](https://ipdx.co), and IPDX is contracted to look after GitHub for this organization.
     # 2. Multiple years of experience managing GitHub organizations of open source projects, including this org.
     - galargh
+    # Stebalien needs temporary owner access so he can configure [issue deletion](https://docs.github.com/en/organizations/managing-organization-settings/allowing-people-to-delete-issues-in-your-organization) so stewards can delete spam.
+    - Stebalien
   member:
     - 2color
     - aamnv
@@ -134,7 +136,6 @@ members:
     - salmad3
     - SgtPooki
     - snazha-blkio
-    - Stebalien
     - stongo
     - stuckinaboot
     - sukunrt


### PR DESCRIPTION
### Summary

Temporary admin privledges for Stebalien to change issue deletion rules.

### Why do you need this?

I'd like to configure [issue deletion](https://docs.github.com/en/organizations/managing-organization-settings/allowing-people-to-delete-issues-in-your-organization) such that all members of the stewards group can delete issues. Otherwise, nobody but owners (as far as I can tell) can delete issues.

### What else do we need to know?

I'm proposing we allow issue deletion by both "github-mgmt stewards" and "w3dt-stewards". Any objections?

**DRI:** myself

### Reviewer's Checklist

- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
