### PR TITLE
Remove dhuseby as a temporary admin

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -14,10 +14,6 @@ members:
     # 3. general long-standing sysadmin for these organizations with his past roles at PL Inc
     # 4. This isn't andyschwab's day-to-day GitHub account
     - andyschwab-admin
-    # Why @dhuseby?
-    # 1. community architect of libp2p setting up KPI infrastructure and migrating Fleek accounts
-    # 2. this is only temporary until [this](https://github.com/libp2p/libp2p/issues/177) and [this](https://github.com/libp2p/libp2p/issues/208) are done.
-    - dhuseby
     # Why @galargh?
     # 1. co-founder of [IPDX](https://ipdx.co), and IPDX is contracted to look after GitHub for this organization.
     # 2. Multiple years of experience managing GitHub organizations of open source projects, including this org.
@@ -50,6 +46,7 @@ members:
     - daviddias
     - dennis-tra
     - dharmapunk82
+    - dhuseby
     - dignifiedquire
     - dirkmc
     - dryajov


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->

Remove dhuseby as a temporary admin.

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->

- https://github.com/libp2p/libp2p/issues/177 is closed.
- https://github.com/libp2p/community/issues/14 is blocked.

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

@dhuseby will need access again in the future once fleek implements the required changes, but that could be 2025 from what I can tell.

**DRI:** @dhuseby?

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request