### PR TITLE
Add w3dt-stewards team as admins for connectivity-site

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -341,6 +341,8 @@ repositories:
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
+      admin:
+        - w3dt-stewards
       pull:
         - github-mgmt stewards
     visibility: public

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -5099,6 +5099,7 @@ teams:
         - dhuseby
         - galargh
       member:
+        - 2color
         - achingbrain
         - aschmahmann
         - guillaumemichel


### PR DESCRIPTION
reviewed @2color (pair programmed)

### Summary
Add w3dt-stewards team as admins for connectivity-site so that we can fix the deploy issues with fleek.

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
