### PR TITLE
add libp2p stewards and js team to js-libp2p-whatwg-fetch

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -354,6 +354,9 @@ repositories:
         - p-shahi
     default_branch: main
     delete_branch_on_merge: false
+    files:
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -931,6 +934,9 @@ repositories:
         - p-shahi
     default_branch: main
     delete_branch_on_merge: false
+    files:
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -3650,6 +3656,13 @@ repositories:
     delete_branch_on_merge: false
     description: Implementation of WHATWG Fetch with support for multiaddrs and
       libp2p streams.
+    files:
+      .github/pull_request_template.md:
+        content: .github/js_pull_request_template.md
+      .github/workflows/semantic-pull-request.yml:
+        content: .github/workflows/semantic-pull-request.yml
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -4670,6 +4683,9 @@ repositories:
         - p-shahi
     default_branch: main
     delete_branch_on_merge: false
+    files:
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -354,9 +354,6 @@ repositories:
         - p-shahi
     default_branch: main
     delete_branch_on_merge: false
-    files:
-      .github/workflows/stale.yml:
-        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -934,9 +931,6 @@ repositories:
         - p-shahi
     default_branch: main
     delete_branch_on_merge: false
-    files:
-      .github/workflows/stale.yml:
-        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -4683,9 +4677,6 @@ repositories:
         - p-shahi
     default_branch: main
     delete_branch_on_merge: false
-    files:
-      .github/workflows/stale.yml:
-        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -3657,6 +3657,14 @@ repositories:
     secret_scanning: true
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
+    teams:
+      admin:
+        - Admin
+        - w3dt-stewards
+      pull:
+        - github-mgmt stewards
+      push:
+        - js-libp2p-dev
     visibility: public
   js-libp2p:
     advanced_security: false


### PR DESCRIPTION
### Summary

Adds the `teams` prop to the js-libp2p-whatwg-fetch repo.

### Why do you need this?

To push branches to the repo.

### What else do we need to know?

N/a

**DRI:** myself

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
