### PR TITLE
Add web3-bot to go-libp2p-pubsub

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -1761,6 +1761,8 @@ repositories:
     collaborators:
       maintain:
         - vyzo
+      push:
+        - web3-bot
     default_branch: master
     delete_branch_on_merge: false
     description: The PubSub implementation for go-libp2p


### PR DESCRIPTION
This is part of the effort to deprecate CircleCI across the organization