### PR TITLE
add guillaumemichel as rust-libp2p Maintainers member

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -5253,6 +5253,7 @@ teams:
         - mxinden
       member:
         - AgeManning
+        - guillaumemichel
         - MarcoPolo
         - thomaseizinger
     privacy: closed


### PR DESCRIPTION
### Summary

add guillaumemichel as rust-libp2p Maintainers member

### Why do you need this?

release rust-libp2p crates

**DRI:** myself

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
