### PR TITLE
Reduce go-libp2p and js-libp2p admins

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -3767,6 +3767,11 @@ repositories:
     advanced_security: false
     allow_update_branch: true
     archived: false
+    collaborators:
+      admin:
+        - achingbrain
+        - aschmahmann
+        - MarcoPolo
     default_branch: main
     delete_branch_on_merge: true
     description: The JavaScript Implementation of libp2p networking stack.
@@ -3785,9 +3790,8 @@ repositories:
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
-      admin:
-        - Admin
-        - w3dt-stewards
+      maintain:
+        - shipyard
       pull:
         - github-mgmt stewards
       push:

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -2119,6 +2119,10 @@ repositories:
         required_status_checks:
           strict: false
     collaborators:
+      admin:
+        - aschmahmann
+        - MarcoPolo
+        - sukunrt
       push:
         - web3-bot
     default_branch: master
@@ -2135,11 +2139,9 @@ repositories:
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
-      admin:
-        - Admin
-        - w3dt-stewards
       maintain:
         - go-libp2p Maintainers
+        - shipyard
       pull:
         - github-mgmt stewards
       push:

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -5251,6 +5251,20 @@ teams:
         - MarcoPolo
         - thomaseizinger
     privacy: closed
+  shipyard:
+    description: Members of Interplanetary Shipyard who work with or on libp2p
+    members:
+      maintainer:
+        - achingbrain
+        - aschmahmann
+        - MarcoPolo
+      member:
+        - 2color
+        - guillaumemichel
+        - lidel
+        - sukunrt
+        - yiannisbot
+    privacy: closed
   Specs contributors:
     members:
       member:


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->
- Introduces a team for members of Interplanetary Shipyard working on or with libp2p (mostly a subset of the existing w3dt-stewards group)
- Reduces the number of admins on go-libp2p
- Reduces the number of admins on js-libp2p


### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->

The number of admin's on both of these repositories is simply too high. As described in earlier github-mgmt permissions reduction permissions are not meant as tokens of credibility, but of utility. Even the number of Admin's here may be too high, but I don't feel like I've overcut given github-mgmt is here to enable escalation.

I don't feel like I've overcut here and I've run this by @achingbrain and @MarcoPolo who are practically speaking the operating admin's of these repos (i.e. if you've used admin permissions and they don't know about it it's a problem). However, if I've overcut it seems fine to merge and re-add relevant permissions later.

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
