### PR TITLE
chore: add Darius to rust-libp2p

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -5241,6 +5241,7 @@ teams:
         - galargh
       member:
         - AgeManning
+        - dariusc93
         - jxs
     privacy: closed
   rust-libp2p Maintainers:


### PR DESCRIPTION
### Summary
Add @dariusc93 to the rust-libp2p maintainers