### PR TITLE
fix: rename rust-libp2p maintainers

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -290,7 +290,7 @@ repositories:
         - Repos - Go
         - Repos - JavaScript
         - rust-libp2p-contributors
-        - rust-libp2p-maintainers
+        - rust-libp2p Maintainers
     topics:
       - type-website
     visibility: public
@@ -615,7 +615,7 @@ repositories:
         - Repos - JavaScript
       push:
         - rust-libp2p-contributors
-        - rust-libp2p-maintainers
+        - rust-libp2p Maintainers
     topics:
       - demo
       - go
@@ -645,7 +645,7 @@ repositories:
     teams:
       admin:
         - Admin
-        - rust-libp2p-maintainers
+        - rust-libp2p Maintainers
         - w3dt-stewards
       pull:
         - contributors
@@ -908,7 +908,7 @@ repositories:
         - go-libp2p Maintainers
         - Repos - Go
         - Repos - JavaScript
-        - rust-libp2p-maintainers
+        - rust-libp2p Maintainers
     topics:
       - documentation
       - knowledge-base
@@ -4184,7 +4184,7 @@ repositories:
         - Repos - Go
         - Repos - JavaScript
         - rust-libp2p-contributors
-        - rust-libp2p-maintainers
+        - rust-libp2p Maintainers
     visibility: public
   npm-go-libp2p-dep:
     advanced_security: false
@@ -4346,7 +4346,7 @@ repositories:
         - Repos - Go
         - Repos - JavaScript
         - rust-libp2p-contributors
-        - rust-libp2p-maintainers
+        - rust-libp2p Maintainers
     visibility: public
   pubsub-notes:
     archived: true
@@ -4555,7 +4555,7 @@ repositories:
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
       admin:
-        - rust-libp2p-maintainers
+        - rust-libp2p Maintainers
       pull:
         - github-mgmt stewards
       push:
@@ -4682,7 +4682,7 @@ repositories:
     squash_merge_commit_title: PR_TITLE
     teams:
       admin:
-        - rust-libp2p-maintainers
+        - rust-libp2p Maintainers
       pull:
         - github-mgmt stewards
       push:
@@ -4759,7 +4759,7 @@ repositories:
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
       admin:
-        - rust-libp2p-maintainers
+        - rust-libp2p Maintainers
       pull:
         - github-mgmt stewards
       push:
@@ -4867,7 +4867,7 @@ repositories:
         - go-libp2p Maintainers
         - Repos - Go
         - Repos - JavaScript
-        - rust-libp2p-maintainers
+        - rust-libp2p Maintainers
     topics:
       - libp2p
     visibility: public
@@ -4901,7 +4901,7 @@ repositories:
         - go-libp2p Maintainers
         - Repos - Go
         - rust-libp2p-contributors
-        - rust-libp2p-maintainers
+        - rust-libp2p Maintainers
     topics:
       - go
       - js
@@ -4985,7 +4985,7 @@ repositories:
       maintain:
         - go-libp2p Maintainers
         - js-libp2p-dev
-        - rust-libp2p-maintainers
+        - rust-libp2p Maintainers
       pull:
         - github-mgmt stewards
     topics:
@@ -5386,7 +5386,7 @@ teams:
         - mxinden
         - thomaseizinger
     privacy: secret
-  rust-libp2p-maintainers:
+  rust-libp2p Maintainers:
     create_default_maintainer: false
     description: "Current maintainers of Rust-libp2p"
     members:

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -289,8 +289,8 @@ repositories:
         - go-libp2p Maintainers
         - Repos - Go
         - Repos - JavaScript
-        - rust-libp2p-contributors
         - rust-libp2p Maintainers
+        - rust-libp2p-contributors
     topics:
       - type-website
     visibility: public
@@ -614,8 +614,8 @@ repositories:
         - Repos - Go
         - Repos - JavaScript
       push:
-        - rust-libp2p-contributors
         - rust-libp2p Maintainers
+        - rust-libp2p-contributors
     topics:
       - demo
       - go
@@ -2943,6 +2943,10 @@ repositories:
           4. Push to the Branch (`git push origin feature/amazing-example`)
 
           5. Open a Pull Request
+      .github/workflows/semantic-pull-request.yml:
+        content: .github/workflows/semantic-pull-request.yml
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -3049,6 +3053,10 @@ repositories:
           4. Push to the Branch (`git push origin feature/amazing-example`)
 
           5. Open a Pull Request
+      .github/workflows/semantic-pull-request.yml:
+        content: .github/workflows/semantic-pull-request.yml
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -3210,6 +3218,10 @@ repositories:
           4. Push to the Branch (`git push origin feature/amazing-example`)
 
           5. Open a Pull Request
+      .github/workflows/semantic-pull-request.yml:
+        content: .github/workflows/semantic-pull-request.yml
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -3261,6 +3273,10 @@ repositories:
           4. Push to the Branch (`git push origin feature/amazing-example`)
 
           5. Open a Pull Request
+      .github/workflows/semantic-pull-request.yml:
+        content: .github/workflows/semantic-pull-request.yml
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -3341,6 +3357,10 @@ repositories:
           4. Push to the Branch (`git push origin feature/amazing-example`)
 
           5. Open a Pull Request
+      .github/workflows/semantic-pull-request.yml:
+        content: .github/workflows/semantic-pull-request.yml
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -3489,6 +3509,10 @@ repositories:
           4. Push to the Branch (`git push origin feature/amazing-example`)
 
           5. Open a Pull Request
+      .github/workflows/semantic-pull-request.yml:
+        content: .github/workflows/semantic-pull-request.yml
+      .github/workflows/stale.yml:
+        content: .github/workflows/stale.yml
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -4183,8 +4207,8 @@ repositories:
         - go-libp2p Maintainers
         - Repos - Go
         - Repos - JavaScript
-        - rust-libp2p-contributors
         - rust-libp2p Maintainers
+        - rust-libp2p-contributors
     visibility: public
   npm-go-libp2p-dep:
     advanced_security: false
@@ -4345,8 +4369,8 @@ repositories:
         - go-libp2p Maintainers
         - Repos - Go
         - Repos - JavaScript
-        - rust-libp2p-contributors
         - rust-libp2p Maintainers
+        - rust-libp2p-contributors
     visibility: public
   pubsub-notes:
     archived: true
@@ -4900,8 +4924,8 @@ repositories:
       push:
         - go-libp2p Maintainers
         - Repos - Go
-        - rust-libp2p-contributors
         - rust-libp2p Maintainers
+        - rust-libp2p-contributors
     topics:
       - go
       - js
@@ -5376,6 +5400,15 @@ teams:
         - vasco-santos
         - whizzzkid
     privacy: closed
+  rust-libp2p Maintainers:
+    create_default_maintainer: false
+    description: "Current maintainers of Rust-libp2p"
+    members:
+      maintainer:
+        - AgeManning
+        - guillaumemichel
+        - jxs
+    privacy: closed
   rust-libp2p-contributors:
     create_default_maintainer: false
     description: "Contributors to the rust-libp2p repository"
@@ -5386,15 +5419,6 @@ teams:
         - mxinden
         - thomaseizinger
     privacy: secret
-  rust-libp2p Maintainers:
-    create_default_maintainer: false
-    description: "Current maintainers of Rust-libp2p"
-    members:
-      maintainer:
-        - AgeManning
-        - guillaumemichel
-        - jxs
-    privacy: closed
   shipyard:
     create_default_maintainer: false
     description: Members of Interplanetary Shipyard who work with or on libp2p


### PR DESCRIPTION
### Summary
https://github.com/libp2p/github-mgmt/pull/252/ seems to have broken the link between the name of the group on this config file and the actual ACL on crates.io, this PR attempts to fix that