### PR TITLE
Promoting @seetadev to py-libp2p maintainer

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -129,6 +129,7 @@ members:
     - rolfyone
     - romanb
     - salmad3
+    - seetadev
     - SgtPooki
     - snazha-blkio
     - Stebalien
@@ -5496,6 +5497,7 @@ teams:
         - pacrob
       member:
         - dhuseby
+        - seetadev
     privacy: closed
   Repos - Go:
     description: For all things go-libp2p


### PR DESCRIPTION
Signed-off-by: Dave Grantham <dwg@linuxprogrammer.org>

### Summary
Manu Sheel has been an active contributor to py-libp2p for 6 months and is currently in charge of the effort to add QUIC transport. 

### Why do you need this?
Promoting him to maintainer increases the overall velocity of the py-libp2p team and shares the review burden created by the significant increase in contributions.

### What else do we need to know?
He's a great guy and fun to work with.

**DRI:** myself
@galargh

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
