### PR TITLE
add rust-asynchronous-codec to mgmt

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4473,6 +4473,50 @@ repositories:
     visibility: public
   research:
     archived: true
+  rust-asynchronous-codec:
+    advanced_security: false
+    allow_update_branch: false
+    archived: false
+    branch_protection:
+      master:
+        allows_deletions: false
+        allows_force_pushes: false
+        blocks_creations: false
+        enforce_admins: false
+        lock_branch: false
+        require_conversation_resolution: false
+        require_signed_commits: false
+        required_linear_history: false
+        required_pull_request_reviews:
+          dismiss_stale_reviews: false
+          require_code_owner_reviews: false
+          required_approving_review_count: 1
+          restrict_dismissals: false
+        required_status_checks:
+          contexts:
+            - build
+          strict: false
+    collaborators:
+      push:
+        - web3-bot
+    default_branch: master
+    delete_branch_on_merge: false
+    description: Multiplexer over reliable, ordered connections.
+    has_discussions: false
+    merge_commit_message: PR_TITLE
+    merge_commit_title: MERGE_MESSAGE
+    secret_scanning_push_protection: true
+    secret_scanning: true
+    squash_merge_commit_message: COMMIT_MESSAGES
+    squash_merge_commit_title: COMMIT_OR_PR_TITLE
+    teams:
+      admin:
+        - rust-libp2p Maintainers
+      pull:
+        - github-mgmt stewards
+      push:
+        - rust-libp2p-contributors
+    visibility: public
   rust-libp2p-identity:
     advanced_security: false
     allow_update_branch: false
@@ -4630,50 +4674,6 @@ repositories:
     default_branch: master
     delete_branch_on_merge: false
     description: Utilities for encoding and decoding frames using async/await.
-    has_discussions: false
-    merge_commit_message: PR_TITLE
-    merge_commit_title: MERGE_MESSAGE
-    secret_scanning_push_protection: true
-    secret_scanning: true
-    squash_merge_commit_message: COMMIT_MESSAGES
-    squash_merge_commit_title: COMMIT_OR_PR_TITLE
-    teams:
-      admin:
-        - rust-libp2p Maintainers
-      pull:
-        - github-mgmt stewards
-      push:
-        - rust-libp2p-contributors
-    visibility: public
-  rust-asynchronous-codec:
-    advanced_security: false
-    allow_update_branch: false
-    archived: false
-    branch_protection:
-      master:
-        allows_deletions: false
-        allows_force_pushes: false
-        blocks_creations: false
-        enforce_admins: false
-        lock_branch: false
-        require_conversation_resolution: false
-        require_signed_commits: false
-        required_linear_history: false
-        required_pull_request_reviews:
-          dismiss_stale_reviews: false
-          require_code_owner_reviews: false
-          required_approving_review_count: 1
-          restrict_dismissals: false
-        required_status_checks:
-          contexts:
-            - build
-          strict: false
-    collaborators:
-      push:
-        - web3-bot
-    default_branch: master
-    delete_branch_on_merge: false
-    description: Multiplexer over reliable, ordered connections.
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4629,6 +4629,50 @@ repositories:
         - web3-bot
     default_branch: master
     delete_branch_on_merge: false
+    description: Utilities for encoding and decoding frames using async/await.
+    has_discussions: false
+    merge_commit_message: PR_TITLE
+    merge_commit_title: MERGE_MESSAGE
+    secret_scanning_push_protection: true
+    secret_scanning: true
+    squash_merge_commit_message: COMMIT_MESSAGES
+    squash_merge_commit_title: COMMIT_OR_PR_TITLE
+    teams:
+      admin:
+        - rust-libp2p Maintainers
+      pull:
+        - github-mgmt stewards
+      push:
+        - rust-libp2p-contributors
+    visibility: public
+  rust-asynchronous-codec:
+    advanced_security: false
+    allow_update_branch: false
+    archived: false
+    branch_protection:
+      master:
+        allows_deletions: false
+        allows_force_pushes: false
+        blocks_creations: false
+        enforce_admins: false
+        lock_branch: false
+        require_conversation_resolution: false
+        require_signed_commits: false
+        required_linear_history: false
+        required_pull_request_reviews:
+          dismiss_stale_reviews: false
+          require_code_owner_reviews: false
+          required_approving_review_count: 1
+          restrict_dismissals: false
+        required_status_checks:
+          contexts:
+            - build
+          strict: false
+    collaborators:
+      push:
+        - web3-bot
+    default_branch: master
+    delete_branch_on_merge: false
     description: Multiplexer over reliable, ordered connections.
     has_discussions: false
     merge_commit_message: PR_TITLE


### PR DESCRIPTION
### Summary
https://github.com/libp2p/rust-asynchronous-codec/ has recently been moved to the org, this PR adds the repo to mgmt