### PR TITLE
give push permissions on specs repo to rust-libp2p maintainers

### DIFF
--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4761,6 +4761,7 @@ repositories:
         - github-mgmt stewards
       push:
         - go-libp2p Maintainers
+        - rust-libp2p Maintainers
         - Repos - Go
         - Repos - JavaScript
         - Specs contributors

--- a/github/libp2p.yml
+++ b/github/libp2p.yml
@@ -4761,9 +4761,9 @@ repositories:
         - github-mgmt stewards
       push:
         - go-libp2p Maintainers
-        - rust-libp2p Maintainers
         - Repos - Go
         - Repos - JavaScript
+        - rust-libp2p Maintainers
         - Specs contributors
     visibility: public
   team-mgmt:


### PR DESCRIPTION
### Summary
give push/write permissions and subsequently allow  members of the `rust-libp2p` to approve spec PR's